### PR TITLE
Enable Prometheus config

### DIFF
--- a/stable/aws-cloudwatch-metrics/README.md
+++ b/stable/aws-cloudwatch-metrics/README.md
@@ -32,4 +32,5 @@ helm upgrade --install aws-cloudwatch-metrics \
 | `nodeSelector` | Node labels for pod assignment	 | {} | 
 | `tolerations` | Optional deployment tolerations	 | {} | 
 | `annotations` | Optional pod annotations	 | {} | 
+| `prometheus.enabled` | Enables specifying Prometheus config. If set to `true`, include `prometheus.yaml` in `config` map.	 | `false` | 
 | `config` | Configuration for CloudWatch agent	 | See [values.yaml](./values.yaml) | ✔

--- a/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
@@ -34,10 +34,10 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: CI_VERSION
-          value: "k8s/1.2.2"
+          value: "k8s/1.3.9"
         # Please don't change the mountPath
         volumeMounts:
-        - name: cwagentconfig
+        - name: cwagent-config
           mountPath: /etc/cwagentconfig
         - name: rootfs
           mountPath: /rootfs
@@ -54,12 +54,27 @@ spec:
         - name: devdisk
           mountPath: /dev/disk
           readOnly: true
+        {{- if .Values.prometheus.enabled }}
+        - name: prometheus-config
+          mountPath: /etc/prometheusconfig
+        {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
       volumes:
-      - name: cwagentconfig
+      - name: cwagent-config
         configMap:
           name: {{ include "aws-cloudwatch-metrics.fullname" . }}
+          items:
+          - key: cwagentconfig.json
+            path: cwagentconfig.json
+      {{- if .Values.prometheus.enabled }}
+      - name: prometheus-config
+        configMap:
+          name: {{ include "aws-cloudwatch-metrics.fullname" . }}
+          items:
+          - key: prometheus.yaml
+            path: prometheus.yaml
+      {{- end }}
       - name: rootfs
         hostPath:
           path: /
@@ -75,6 +90,17 @@ spec:
       - name: devdisk
         hostPath:
           path: /dev/disk/
+      {{- range .Values.additionalConfigVolumes }}
+      - name: {{ .name }}
+        {{- with .configMap }}
+        configMap:
+          name: {{ tpl .name $ }}
+          {{- with .items }}
+          items:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
       terminationGracePeriodSeconds: 60
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -25,6 +25,9 @@ tolerations: []
 
 affinity: {}
 
+prometheus:
+  enabled: false
+
 config:
   cwagentconfig.json: |
     {
@@ -38,3 +41,9 @@ config:
         "force_flush_interval": 5
       }
     }
+  # Provide Prometheus config YAML if prometheus.enabled is true
+  # prometheus.yaml: |
+  #   global:
+  #     scrape_interval: 1m
+  #     scrape_timeout: 10s
+  #   # Add additional Prometheus config here, e.g. scrape_configs


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
Issue #413 
Issue #356 

### Description of changes

<!-- Please explain the changes you made here. -->
- Added ability to pass custom CloudWatch agent configuration
- Added ability to enable additional Prometheus config
- Replaced docker.io image repo by public ECR

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->
Tested by deploying the updated Helm chart in an EKS cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
