### PR TITLE
Enable adding additional Prometheus config

### DIFF
--- a/stable/aws-cloudwatch-metrics/README.md
+++ b/stable/aws-cloudwatch-metrics/README.md
@@ -32,5 +32,5 @@ helm upgrade --install aws-cloudwatch-metrics \
 | `nodeSelector` | Node labels for pod assignment	 | {} | 
 | `tolerations` | Optional deployment tolerations	 | {} | 
 | `annotations` | Optional pod annotations	 | {} | 
-| `prometheus.enabled` | Enables specifying Prometheus config. If set to `true`, include `prometheus.yaml` in `config` map.	 | `false` | 
 | `config` | Configuration for CloudWatch agent	 | See [values.yaml](./values.yaml) | ✔
+| `prometheusConfig` | Prometheus configuration for CloudWatch agent	 | {} | 

--- a/stable/aws-cloudwatch-metrics/templates/configmap.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/configmap.yaml
@@ -9,3 +9,15 @@ data:
   {{$key }}: |
     {{- tpl $value $ | nindent 4 }}
 {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "aws-cloudwatch-metrics.fullname" . }}-prometheus
+  labels:
+    {{- include "aws-cloudwatch-metrics.labels" . | nindent 4 }}
+data:
+{{- range $key, $value := .Values.prometheusConfig }}
+  {{$key }}: |
+    {{- tpl $value $ | nindent 4 }}
+{{- end }}

--- a/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
@@ -54,7 +54,7 @@ spec:
         - name: devdisk
           mountPath: /dev/disk
           readOnly: true
-        {{- if .Values.prometheus.enabled }}
+        {{- with .Values.prometheusConfig }}
         - name: prometheus-config
           mountPath: /etc/prometheusconfig
         {{- end }}
@@ -64,16 +64,10 @@ spec:
       - name: cwagent-config
         configMap:
           name: {{ include "aws-cloudwatch-metrics.fullname" . }}
-          items:
-          - key: cwagentconfig.json
-            path: cwagentconfig.json
-      {{- if .Values.prometheus.enabled }}
+      {{- with .Values.prometheusConfig }}
       - name: prometheus-config
         configMap:
-          name: {{ include "aws-cloudwatch-metrics.fullname" . }}
-          items:
-          - key: prometheus.yaml
-            path: prometheus.yaml
+          name: {{ include "aws-cloudwatch-metrics.fullname" $ }}-prometheus
       {{- end }}
       - name: rootfs
         hostPath:

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -25,9 +25,6 @@ tolerations: []
 
 affinity: {}
 
-prometheus:
-  enabled: false
-
 config:
   cwagentconfig.json: |
     {
@@ -41,9 +38,24 @@ config:
         "force_flush_interval": 5
       }
     }
-  # Provide Prometheus config YAML if prometheus.enabled is true
+
+prometheusConfig: {}
+  # # Optional: provide Prometheus config YAML here
   # prometheus.yaml: |
   #   global:
   #     scrape_interval: 1m
   #     scrape_timeout: 10s
-  #   # Add additional Prometheus config here, e.g. scrape_configs
+  #   scrape_configs:
+  #     # Add scrape configs here
+  #     [ - <scrape_config> ... ]
+  #   rule_files:
+  #     # If rules files are included here, ensure they are also included
+  #     # as additional keys of this prometheusConfig map
+  #     - prometheus_rules.yaml
+
+  # prometheus_rules.yaml: |
+  #   groups:
+  #     - name: example
+  #       rules:
+  #       - record: job:http_inprogress_requests:sum
+  #         expr: sum by (job) (http_inprogress_requests)


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
Issue #413 
Issue #356 

### Description of changes

<!-- Please explain the changes you made here. -->
- Added ability to pass custom CloudWatch agent configuration
- Added ability to enable additional Prometheus config
- Replaced docker.io image repo by public ECR

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

<!-- Please explain what testing was done. -->
Tested by deploying the updated Helm chart in an EKS cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
